### PR TITLE
DB 및 JPA 관련 설정 오류 사항 수정

### DIFF
--- a/studycafe/src/main/resources/application.properties
+++ b/studycafe/src/main/resources/application.properties
@@ -1,16 +1,16 @@
-# DataBase ??
-spring.datasource.url=jdbc:mysql://sca-scanner-db.cofusbyz8zbd.ap-northeast-1.rds.amazonaws.com:3306
+# DataBase
+spring.datasource.url=jdbc:mysql://sca-scanner-db.cofusbyz8zbd.ap-northeast-1.rds.amazonaws.com:3306/demo?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=admin
 spring.datasource.password=tmzktmzosjsjem
 spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 
-# JPA ??
+# JPA
 spring.jpa.hibernate.ddl-auto=none
-spring.jpa.generate-ddl=false
+spring.jpa.generate-ddl=true
 spring.jpa.show-sql=true
 spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.properties.hibernate.format_sql=true
 
-# hibernate logging ??
+# hibernate logging
 logging.level.org.hibernate=debug


### PR DESCRIPTION
서버를 구동할 때 `@Entity`를 적용한 클래스들이 테이블로 생성되지 않는 오류가 발생했습니다. `application.properties` 에 스키마를 명시하지 않고, JPA의 ddl 옵션을 꺼놨기 때문이였다. 이를 발견하여 설정을 수정함으로써 오류를 해결했습니다.

DataBase
- 기존 url 속성에서 스키마명을 명시하지 않은 것을 명시

JPA
- ddl 옵션을 true로 하여 서버 구동시 테이블이 자동으로 생성되도록 설정