### PR TITLE
스터디 카페, 룸 수정 기능 수정 및 수정 DTO 추가, 각각의 엔티티와 DTO에 @Builder 적용 및 기타 

### DIFF
--- a/studycafe/src/main/java/com/scascanner/studycafe/domain/entity/Room.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/domain/entity/Room.java
@@ -2,6 +2,7 @@ package com.scascanner.studycafe.domain.entity;
 
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
@@ -13,6 +14,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Room {
 
@@ -27,10 +29,6 @@ public class Room {
 
     private Integer headCount;
     private Integer price;
-
-    public Long getId() {
-        return id;
-    }
 
     public void update(Integer headCount, Integer price) {
         this.headCount = headCount;

--- a/studycafe/src/main/java/com/scascanner/studycafe/domain/entity/StudyCafe.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/domain/entity/StudyCafe.java
@@ -34,8 +34,16 @@ public class StudyCafe {
     private String address;
     private String comment;
 
-    public Long getId() {
-        return id;
+    @Builder
+    public StudyCafe(Long id, Owner owner, String name, Integer minUsingTime, LocalTime openTime, LocalTime closeTime, String address, String comment) {
+        this.id = id;
+        this.owner = owner;
+        this.name = name;
+        this.minUsingTime = minUsingTime;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+        this.address = address;
+        this.comment = comment;
     }
 
     public void update(String name, Integer minUsingTime, LocalTime openTime, LocalTime closeTime, String address, String comment) {

--- a/studycafe/src/main/java/com/scascanner/studycafe/domain/entity/StudyCafe.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/domain/entity/StudyCafe.java
@@ -1,6 +1,7 @@
 package com.scascanner.studycafe.domain.entity;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/studycafe/src/main/java/com/scascanner/studycafe/domain/entity/StudyCafe.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/domain/entity/StudyCafe.java
@@ -8,6 +8,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -19,7 +20,7 @@ import java.time.LocalTime;
 public class StudyCafe {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "study_cafe_id")
     private Long id;
 

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/login/dto/UserForm.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/login/dto/UserForm.java
@@ -42,13 +42,12 @@ public class UserForm {
     }
 
     public User toEntity(){
-        User user = User.builder()
+        return User.builder()
                 .email(email)
                 .password(new BCryptPasswordEncoder().encode(password))
                 .nickname(nickname)
                 .name(name)
                 .birthday(birthday)
                 .build();
-        return user;
     }
 }

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/controller/RoomController.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/controller/RoomController.java
@@ -2,10 +2,9 @@ package com.scascanner.studycafe.web.studycafe.controller;
 
 import com.scascanner.studycafe.domain.entity.Room;
 import com.scascanner.studycafe.web.studycafe.dto.RoomDto;
-import com.scascanner.studycafe.web.studycafe.dto.RoomEditDto;
+import com.scascanner.studycafe.web.studycafe.dto.RoomEditFormDto;
 import com.scascanner.studycafe.web.studycafe.service.RoomService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,21 +28,38 @@ public class RoomController {
      * @return
      */
     @GetMapping("/studycafe/{cafeId}/room")
-    public List<Room> rooms(Model model, @PathVariable Long cafeId) {
+    public List<RoomDto> rooms(Model model, @PathVariable Long cafeId) {
 
-        List<Room> rooms = roomService.findAllInStudyCafe(cafeId);
+        List<RoomDto> rooms = roomService.findAllInStudyCafe(cafeId).stream()
+                .map(r -> RoomDto
+                        .builder()
+                        .id(r.getId())
+                        .studyCafe(r.getStudyCafe())
+                        .headCount(r.getHeadCount())
+                        .price(r.getPrice())
+                        .build()
+                ).collect(Collectors.toList());
+
         model.addAttribute("rooms", rooms);
 
         return rooms;
     }
 
-    @GetMapping("/studycafe/{cafeId}/rooms/{roomId}")
-    public Room room(Model model, @PathVariable Long cafeId, @PathVariable Long roomId) {
+    @GetMapping("/studycafe/{cafeId}/room/{roomId}")
+    public RoomDto room(Model model, @PathVariable Long cafeId, @PathVariable Long roomId) {
 
         Room room = roomService.findOneInStudyCafe(cafeId, roomId);
-        model.addAttribute("room", room);
 
-        return room;
+        RoomDto roomDto = RoomDto.builder()
+                .id(room.getId())
+                .studyCafe(room.getStudyCafe())
+                .headCount(room.getHeadCount())
+                .price(room.getPrice())
+                .build();
+
+        model.addAttribute("room", roomDto);
+
+        return roomDto;
     }
 
     @GetMapping("/studycafe/{cafeId}/rooms/{roomId}/edit")

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/controller/RoomController.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/controller/RoomController.java
@@ -62,12 +62,13 @@ public class RoomController {
         return roomDto;
     }
 
-    @GetMapping("/studycafe/{cafeId}/rooms/{roomId}/edit")
-    public RoomEditDto editRoomForm(@PathVariable String cafeId, @PathVariable Long roomId, Model model) {
+    @GetMapping("/studycafe/{cafeId}/room/{roomId}/edit")
+    public RoomEditFormDto editRoomForm(@PathVariable String cafeId, @PathVariable Long roomId, Model model) {
 
-        RoomEditDto roomEditDto = new RoomEditDto();
-        model.addAttribute("form", roomEditDto);
-        return roomEditDto;
+        RoomEditFormDto roomEditFormDto = new RoomEditFormDto();
+        model.addAttribute("form", roomEditFormDto);
+
+        return roomEditFormDto;
 
         // return 뷰 논리 이름
     }
@@ -79,10 +80,10 @@ public class RoomController {
      * @param roomId
      * @return
      */
-    @PostMapping("/studycafe/{cafeId}/rooms/{roomId}/edit")
-    public void edit(@ModelAttribute RoomEditDto roomEditDto, Model model, @PathVariable Long cafeId, @PathVariable Long roomId) {
+    @PostMapping("/studycafe/{cafeId}/room/{roomId}/edit")
+    public void edit(@Validated @RequestBody RoomEditFormDto roomEditFormDto, Model model, @PathVariable Long cafeId, @PathVariable Long roomId) {
 
-        roomService.updateRoom(roomId, roomEditDto);
+        roomService.updateRoom(roomId, roomEditFormDto);
 
         // 리다이렉트 ("redirect:/studycafe/{cafeId}/rooms")
     }

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/controller/RoomController.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/controller/RoomController.java
@@ -6,6 +6,7 @@ import com.scascanner.studycafe.web.studycafe.dto.RoomEditFormDto;
 import com.scascanner.studycafe.web.studycafe.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ui.Model;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/controller/StudyCafeController.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/controller/StudyCafeController.java
@@ -1,15 +1,13 @@
 package com.scascanner.studycafe.web.studycafe.controller;
 
 import com.scascanner.studycafe.domain.entity.StudyCafe;
+import com.scascanner.studycafe.web.studycafe.dto.StudyCafeAddFormDto;
 import com.scascanner.studycafe.web.studycafe.dto.StudyCafeDto;
 import com.scascanner.studycafe.web.studycafe.service.StudyCafeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,20 +20,21 @@ public class StudyCafeController {
     private final StudyCafeService studyCafeService;
 
     @GetMapping("/studycafe/new")
-    public StudyCafeDto addForm(Model model) {
-        StudyCafeDto studyCafeDto = new StudyCafeDto();
-        model.addAttribute("form", studyCafeDto);
+    public StudyCafeAddFormDto addForm(Model model) {
+        StudyCafeAddFormDto studyCafeAddFormDto = new StudyCafeAddFormDto();
+        model.addAttribute("form", studyCafeAddFormDto);
 
-        return studyCafeDto;
+        return studyCafeAddFormDto;
 //        return "/studycafe/create";
     }
 
     @PostMapping("/studycafe/new")
-    public String add(StudyCafeDto studyCafeDto) {
-        StudyCafe studyCafe = studyCafeDto.createEntity();
+    public StudyCafe add(@RequestBody StudyCafeDto studyCafeDto) {
+        System.out.println("studyCafeDto = " + studyCafeDto);
+        StudyCafe studyCafe = studyCafeDto.toEntity();
         studyCafeService.addStudyCafe(studyCafe);
 
-        return "ok";
+        return studyCafe;
 //        return "/redirect:/";   // 스터디카페 등록 후 별도의 창을 띄울지는 나중에 결정
     }
 
@@ -48,21 +47,46 @@ public class StudyCafeController {
      */
     @GetMapping("/studycafe")
     public List<StudyCafeDto> studyCafes(Model model) {
-        List<StudyCafeDto> studyCafes = studyCafeService.findStudyCafes().stream().map(StudyCafeDto::mapToDto).collect(Collectors.toList());
-        model.addAttribute("studyCafes", studyCafes);
+        List<StudyCafeDto> studyCafeDtos = studyCafeService.findStudyCafes().stream().map(s -> StudyCafeDto.builder()
+                .id(s.getId())
+                .owner(s.getOwner())
+                .name(s.getName())
+                .minUsingTime(s.getMinUsingTime())
+                .openTime(s.getOpenTime())
+                .closeTime(s.getCloseTime())
+                .address(s.getAddress())
+                .comment(s.getComment())
+                .build()).collect(Collectors.toList());
 
-        return studyCafes;
+        System.out.println(studyCafeDtos.get(0));
+        System.out.println(studyCafeDtos.get(1));
+
+        model.addAttribute("studyCafes", studyCafeDtos);
+        return studyCafeDtos;
     }
 
     @GetMapping("/studycafe/{cafeId}")
     public StudyCafeDto studyCafe(@PathVariable Long cafeId, Model model) {
 
-        StudyCafeDto studyCafe = StudyCafeDto.mapToDto(studyCafeService.findById(cafeId));
+        StudyCafe studyCafe = studyCafeService.findById(cafeId);
+
+
+        StudyCafeDto studyCafeDto = StudyCafeDto.builder()
+                                        .id(studyCafe.getId())
+                                        .owner(studyCafe.getOwner())
+                                        .name(studyCafe.getName())
+                                        .minUsingTime(studyCafe.getMinUsingTime())
+                                        .openTime(studyCafe.getOpenTime())
+                                        .closeTime(studyCafe.getCloseTime())
+                                        .address(studyCafe.getAddress())
+                                        .comment(studyCafe.getComment())
+                                    .build();
+
         model.addAttribute("studycafe", studyCafe);
 
         // 뷰에서 뭔가 정보를 깔끔하게 띄어주면 좋을 것 같음
 
-        return studyCafe;
+        return studyCafeDto;
 //        return "/studycafe/" + cafeId;  // 이거 더 편하게 하는 방법이 있었는데 기억 안남...
     }
 }

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/controller/StudyCafeController.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/controller/StudyCafeController.java
@@ -3,10 +3,12 @@ package com.scascanner.studycafe.web.studycafe.controller;
 import com.scascanner.studycafe.domain.entity.StudyCafe;
 import com.scascanner.studycafe.web.studycafe.dto.StudyCafeAddFormDto;
 import com.scascanner.studycafe.web.studycafe.dto.StudyCafeDto;
+import com.scascanner.studycafe.web.studycafe.dto.StudyCafeEditFormDto;
 import com.scascanner.studycafe.web.studycafe.service.StudyCafeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ui.Model;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -36,6 +38,13 @@ public class StudyCafeController {
 
         return studyCafe;
 //        return "/redirect:/";   // 스터디카페 등록 후 별도의 창을 띄울지는 나중에 결정
+    }
+
+    @PostMapping("/studycafe/{cafeId}/edit")
+    public StudyCafeEditFormDto edit(@Validated @RequestBody StudyCafeEditFormDto studyCafeEditFormDto, @PathVariable Long cafeId) {
+
+        studyCafeService.update(cafeId, studyCafeEditFormDto);
+        return studyCafeEditFormDto;
     }
 
     /**

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/dto/RoomEditFormDto.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/dto/RoomEditFormDto.java
@@ -3,21 +3,22 @@ package com.scascanner.studycafe.web.studycafe.dto;
 import com.scascanner.studycafe.domain.entity.Room;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 
 @Getter
 @Setter
-public class RoomEditDto {
+public class RoomEditFormDto {
     private Long id;
 
-    @NotBlank(message = "인원 수는 공백일 수 없습니다.")
+    @NotNull(message = "인원 수는 공백일 수 없습니다.")
     @Min(message = "인원수는 최소 1 이상이여야 합니다.", value = 1)
     private Integer headCount;
 
-    @NotBlank(message = "가격은 공백일 수 없습니다.")
+    @NotNull(message = "가격은 공백일 수 없습니다.")
     @Positive(message = "적절한 가격을 입력해주세요.")
     private Integer price;
 

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/dto/StudyCafeDto.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/dto/StudyCafeDto.java
@@ -2,48 +2,49 @@ package com.scascanner.studycafe.web.studycafe.dto;
 
 import com.scascanner.studycafe.domain.entity.Owner;
 import com.scascanner.studycafe.domain.entity.StudyCafe;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import org.modelmapper.ModelMapper;
+import lombok.ToString;
 
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
 import java.time.LocalTime;
 
 @Getter
 @Setter
+@ToString
 public class StudyCafeDto {
 
     private Long id;
-
     private Owner owner;
-
-    @NotBlank(message = "스터디 카페 이름은 필수입니다.")
     private String name;
-
-    @NotBlank(message = "최소 사용시간은 필수입니다.")
-    @Min(value = 1, message = "최소 사용시간은 1시간 이상이여야 합니다.")
     private Integer minUsingTime;
-
-    // LocalTime 바인딩 오류시 메시지 : 정확한 시간을 입력해주세요.
     private LocalTime openTime;
     private LocalTime closeTime;
-
-    @NotBlank(message = "주소는 필수입니다.")
     private String address;
-
-    @NotBlank(message = "설명은 필수입니다.")
-    @Size(max = 1000, message = "소개글은 최대 1000자까지 작성할 수 있습니다.")
     private String comment;
 
-    private static ModelMapper modelMapper = new ModelMapper();
-
-    public StudyCafe createEntity() {
-        return modelMapper.map(this, StudyCafe.class);
+    @Builder
+    public StudyCafeDto(Long id, Owner owner, String name, Integer minUsingTime, LocalTime openTime, LocalTime closeTime, String address, String comment) {
+        this.id = id;
+        this.owner = owner;
+        this.name = name;
+        this.minUsingTime = minUsingTime;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+        this.address = address;
+        this.comment = comment;
     }
 
-    public static StudyCafeDto mapToDto(StudyCafe studyCafe) {
-        return modelMapper.map(studyCafe, StudyCafeDto.class);
+    public StudyCafe toEntity() {
+        return StudyCafe.builder()
+                .id(id)
+                .owner(owner)
+                .name(name)
+                .minUsingTime(minUsingTime)
+                .openTime(openTime)
+                .closeTime(closeTime)
+                .address(address)
+                .comment(comment)
+                .build();
     }
 }

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/dto/StudyCafeEditFormDto.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/dto/StudyCafeEditFormDto.java
@@ -1,0 +1,58 @@
+package com.scascanner.studycafe.web.studycafe.dto;
+
+import com.scascanner.studycafe.domain.entity.StudyCafe;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class StudyCafeEditFormDto {
+
+    @NotBlank(message = "스터디 카페 이름은 필수입니다.")
+    private String name;
+
+    @NotNull(message = "최소 사용시간은 필수입니다.")
+    @Min(value = 1, message = "최소 사용시간은 1시간 이상이여야 합니다.")
+    private Integer minUsingTime;
+
+    // LocalTime 바인딩 오류시 메시지 : 정확한 시간을 입력해주세요.
+    private LocalTime openTime;
+    private LocalTime closeTime;
+
+    @NotBlank(message = "주소는 필수입니다.")
+    private String address;
+
+    @NotBlank(message = "설명은 필수입니다.")
+    @Size(max = 1000, message = "소개글은 최대 1000자까지 작성할 수 있습니다.")
+    private String comment;
+
+    @Builder
+    public StudyCafeEditFormDto(String name, Integer minUsingTime, LocalTime openTime, LocalTime closeTime, String address, String comment) {
+        this.name = name;
+        this.minUsingTime = minUsingTime;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+        this.address = address;
+        this.comment = comment;
+    }
+
+    public StudyCafe toEntity() {
+        return StudyCafe.builder()
+                .name(name)
+                .minUsingTime(minUsingTime)
+                .openTime(openTime)
+                .closeTime(closeTime)
+                .address(address)
+                .comment(comment)
+                .build();
+    }
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/service/RoomService.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/service/RoomService.java
@@ -2,7 +2,7 @@ package com.scascanner.studycafe.web.studycafe.service;
 
 import com.scascanner.studycafe.domain.entity.Room;
 import com.scascanner.studycafe.domain.repository.RoomRepository;
-import com.scascanner.studycafe.web.studycafe.dto.RoomEditDto;
+import com.scascanner.studycafe.web.studycafe.dto.RoomEditFormDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,10 +17,10 @@ public class RoomService {
     private final RoomRepository roomRepository;
 
     @Transactional
-    public void updateRoom(Long roomId, RoomEditDto roomEditDto) {
+    public void updateRoom(Long roomId, RoomEditFormDto roomEditFormDto) {
 
         Room room = roomRepository.findById(roomId);
-        room.update(roomEditDto.getHeadCount(), roomEditDto.getPrice());
+        room.update(roomEditFormDto.getHeadCount(), roomEditFormDto.getPrice());
     }
 
     public Room findById(Long roomId) {

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/service/StudyCafeService.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/studycafe/service/StudyCafeService.java
@@ -2,10 +2,11 @@ package com.scascanner.studycafe.web.studycafe.service;
 
 import com.scascanner.studycafe.domain.entity.StudyCafe;
 import com.scascanner.studycafe.domain.repository.StudyCafeRepository;
-import com.scascanner.studycafe.web.studycafe.dto.StudyCafeDto;
+import com.scascanner.studycafe.web.studycafe.dto.StudyCafeEditFormDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
@@ -37,18 +38,18 @@ public class StudyCafeService {
     }
 
     /**
-     * 특정 스터디 카페의 최소 사용시간을 수정하는 메소드
+     * 특정 스터디 카페의 내용들을 수정하는 메소드
      * 필터나 인터셉터 사용 가능성 있음
+     * 필드 일부만 수정 가능하도록 추후 리펙토링
      * @param cafeId 특정 스터디 카페 Id
-     * @param minUsingTime 변경할 최소 사용시간
+     * @param studyCafeEditFormDto 변경할 데이터
      */
     @Transactional  // 쓰기를 해야하는 로직은 별도로 어노테이션을 달아준다 (readOnly 디폴트값이 False 이므로)
-    public void updateMinUsingTime(Long cafeId, Integer minUsingTime) {
+    public void update(Long cafeId, StudyCafeEditFormDto studyCafeEditFormDto) {
         StudyCafe studyCafe = studyCafeRepository.findById(cafeId);
-        StudyCafeDto studyCafeDto = StudyCafeDto.mapToDto(studyCafe);
-
-        studyCafeDto.setMinUsingTime(minUsingTime);
-        // 업데이트 쿼리는 별도로 날려야 하는가?
+        studyCafe.update(studyCafeEditFormDto.getName(), studyCafeEditFormDto.getMinUsingTime()
+        , studyCafeEditFormDto.getOpenTime(), studyCafeEditFormDto.getCloseTime(), studyCafeEditFormDto.getAddress()
+        ,studyCafeEditFormDto.getComment());
     }
 
     /**


### PR DESCRIPTION
### 스터디카페
- 기존 `ModelMapper` 사용을 `@Builder`로 완전 대체
- 수정 시 사용할 `StudyCafeEditFormDto` 생성
- 스터디카페 수정 메소드 생성
  - 이는 추후 스터디 카페 항목(필드) 별로 수정 가능하도록 개선할 예정
- 스터디카페 생성 시 샘플 데이터 때문에 PK값이 중복되는 오류를 개선
  - `@GeneratedValue` 의 `strategy` 속성을 `IDENTITY` 로 수정하여 DB를 기준으로 PK값을 생성하도록 수정
- 기존 DTO에서 검증 어노테이션 적용시 문자열이 아닌 필드에 대해 `@NotBlank` 적용을 `@NotNull` 로 수정
  - `@NotBlank` 나 `@NotEmpty` 는 문자열 타입에 대해서만 적용이 가능하다.

### 룸
- 기존 `ModelMapper` 사용을 `@Builder`로 완전 대체
- 수정 시 사용할 `RoomEditFormDto` 생성
- 기존 DTO에서 검증 어노테이션 적용시 문자열이 아닌 필드에 대해 `@NotBlank` 적용을 `@NotNull` 로 수정
  - `@NotBlank` 나 `@NotEmpty` 는 문자열 타입에 대해서만 적용이 가능하다.
