### PR TITLE
최종 결제 승인 관련 누락되었던 클래스 추가 및 User 엔티티에 @Getter 추가

### DIFF
--- a/studycafe/src/main/java/com/scascanner/studycafe/domain/entity/User.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/domain/entity/User.java
@@ -2,6 +2,7 @@ package com.scascanner.studycafe.domain.entity;
 
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
@@ -13,6 +14,7 @@ import java.time.LocalDate;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Builder
 public class User {
 
@@ -26,15 +28,6 @@ public class User {
     private String nickname;
     private String name;
     private LocalDate birthday;
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
 
     public User(String email, String password, String nickname, String name, LocalDate birthday) {
         this.email = email;

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/PaymentStatus.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/PaymentStatus.java
@@ -1,0 +1,16 @@
+package com.scascanner.studycafe.web.pay.response;
+
+/**
+ * 결제 처리 상태입니다. 아래와 같은 상태 값을 가질 수 있습니다. 상태 변화 흐름이 궁금하다면 흐름도를 살펴보세요.
+ * - READY: 결제를 생성하면 가지게 되는 초기 상태 입니다. 인증 전까지는 READY 상태를 유지합니다.
+ * - IN_PROGRESS: 결제 수단 정보와 해당 결제 수단의 소유자가 맞는지 인증을 마친 상태입니다. 결제 승인 API를 호출하면 결제가 완료됩니다.
+ * - WAITING_FOR_DEPOSIT: 가상계좌 결제 흐름에만 있는 상태로, 결제 고객이 발급된 가상계좌에 입금하는 것을 기다리고 있는 상태입니다.
+ * - DONE: 인증된 결제 수단 정보, 고객 정보로 요청한 결제가 승인된 상태입니다.
+ * - CANCELED: 승인된 결제가 취소된 상태입니다.
+ * - PARTIAL_CANCELED: 승인된 결제가 부분 취소된 상태입니다.
+ * - ABORTED: 결제 승인이 실패한 상태입니다.
+ * - EXPIRED: 결제 유효 시간 30분이 지나 거래가 취소된 상태입니다. IN_PROGRESS 상태에서 결제 승인 API를 호출하지 않으면 EXPIRED가 됩니다.
+ */
+public enum PaymentStatus {
+    READY, IN_PROGRESS, WAITING_FOR_DEPOSIT, DONE, CANCELED, PARTIAL_CANCELED, ABORTED, EXPIRED;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/PaymentType.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/PaymentType.java
@@ -1,0 +1,5 @@
+package com.scascanner.studycafe.web.pay.response;
+
+public enum PaymentType {
+    NORMAL, BILLING, BRANDPAY;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/create/PaymentCreateResponse.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/create/PaymentCreateResponse.java
@@ -6,8 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+// CommonPaymentCreateRequest 클래스로 대체
 @Data
-@NoArgsConstructor
 public class PaymentCreateResponse {
 
     private PaymentMethod method;

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/Checkout.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/Checkout.java
@@ -1,0 +1,10 @@
+package com.scascanner.studycafe.web.pay.response.etc;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Checkout {
+    private String url;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/Discount.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/Discount.java
@@ -1,0 +1,10 @@
+package com.scascanner.studycafe.web.pay.response.etc;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Discount {
+    private Integer amount;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/EasyPay.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/EasyPay.java
@@ -1,0 +1,16 @@
+package com.scascanner.studycafe.web.pay.response.etc;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 간편 결제 정보
+ */
+@Data
+@NoArgsConstructor
+public class EasyPay {
+
+    private String provider;
+    private Integer amount;
+    private Integer discountAmount;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/Failure.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/Failure.java
@@ -1,0 +1,12 @@
+package com.scascanner.studycafe.web.pay.response.etc;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Failure {
+
+    private String code;
+    private String message;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/GiftCertificate.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/GiftCertificate.java
@@ -1,0 +1,17 @@
+package com.scascanner.studycafe.web.pay.response.etc;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Data
+@NoArgsConstructor
+public class GiftCertificate {
+
+    @Length(max = 8, message = "결제 승인번호는 최대 8자 입니다.")
+    private String approveNo;
+
+    @JsonValue
+    private SettlementStatus settlementStatus;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/MobilePhone.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/MobilePhone.java
@@ -1,0 +1,16 @@
+package com.scascanner.studycafe.web.pay.response.etc;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class MobilePhone {
+
+    private String customerMobilePhone;
+
+    @JsonValue
+    private SettlementStatus settlementStatus;
+    private String receiptUrl;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/Receipt.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/Receipt.java
@@ -1,0 +1,10 @@
+package com.scascanner.studycafe.web.pay.response.etc;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Receipt {
+    private String url;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/SettlementStatus.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/SettlementStatus.java
@@ -1,0 +1,8 @@
+package com.scascanner.studycafe.web.pay.response.etc;
+
+/**
+ * 정산 상태입니다. 정산이 아직 되지 않았다면 INCOMPLETED, 정산이 완료됐다면 COMPLETED 값이 들어옵니다.
+ */
+public enum SettlementStatus {
+    INCOMPLETED, COMPLETED
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/Transfer.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/Transfer.java
@@ -1,0 +1,15 @@
+package com.scascanner.studycafe.web.pay.response.etc;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Transfer {
+
+    private String bankCode;    // 추후 리펙토링
+
+    @JsonValue
+    private SettlementStatus settlementStatus;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/card/AcquireStatus.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/card/AcquireStatus.java
@@ -1,0 +1,13 @@
+package com.scascanner.studycafe.web.pay.response.etc.card;
+
+/**
+ * 카드 결제의 매입 상태입니다. 아래와 같은 상태 값을 가질 수 있습니다.
+ * - READY: 아직 매입 요청이 안 된 상태입니다.
+ * - REQUESTED: 매입이 요청된 상태입니다.
+ * - COMPLETED: 요청된 매입이 완료된 상태입니다.
+ * - CANCEL_REQUESTED: 매입 취소가 요청된 상태입니다.
+ * - CANCELED: 요청된 매입 취소가 완료된 상태입니다.
+ */
+public enum AcquireStatus {
+    READY, REQUESTED, COMPLETED, CANCEL_REQUESTED, CANCELED
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/card/Card.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/card/Card.java
@@ -1,0 +1,32 @@
+package com.scascanner.studycafe.web.pay.response.etc.card;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Card {
+    private Integer amount;
+    private String issuerCode;
+    private String acquirerCode;
+    private String number;
+    private Integer installmentPlanMonths;  // 할부 개월수, 무이자면 0
+    private String approveNo;
+    private String useCardPoint;
+    private String receiptUrl;
+
+//    @JsonValue
+    private String  cardType;
+
+//    @JsonValue
+    private String  ownerType;
+
+//    @JsonValue
+    private String acquireStatus;
+
+    private boolean isInterestFree; // 무이자 할부 적용 여부
+
+//    @JsonValue
+    private String interestPayer;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/card/CardType.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/card/CardType.java
@@ -1,0 +1,5 @@
+package com.scascanner.studycafe.web.pay.response.etc.card;
+
+public enum CardType {
+    신용, 체크, 기프트
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/card/InterestPayer.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/card/InterestPayer.java
@@ -1,0 +1,11 @@
+package com.scascanner.studycafe.web.pay.response.etc.card;
+
+/**
+ * 무이자 할부가 적용된 결제에서 할부 수수료를 부담하는 주체입니다. BUYER, CARD_COMPANY, MERCHANT 중 하나입니다.
+ * - BUYER: 상품을 구매한 고객이 할부 수수료를 부담합니다.
+ * - CARD_COMPANY: 카드사에서 할부 수수료를 부담합니다.
+ * - MERCHANT: 상점에서 할부 수수료를 부담합니다.
+ */
+public enum InterestPayer {
+    BUYER, CARD_COMPANY, MERCHANT
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/card/OwnerType.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/card/OwnerType.java
@@ -1,0 +1,5 @@
+package com.scascanner.studycafe.web.pay.response.etc.card;
+
+public enum OwnerType {
+    개인, 법인
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/cardreceipt/CashReceipt.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/cardreceipt/CashReceipt.java
@@ -1,0 +1,23 @@
+package com.scascanner.studycafe.web.pay.response.etc.cardreceipt;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CashReceipt {
+
+    private String receiptKey;
+
+//    @JsonValue
+    private String type;
+
+    private Integer amount;
+
+    private Integer taxFreeAmount;
+
+    private String issueNumber;
+
+    private String receiptUrl;
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/cardreceipt/CashReceiptType.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/cardreceipt/CashReceiptType.java
@@ -1,0 +1,5 @@
+package com.scascanner.studycafe.web.pay.response.etc.cardreceipt;
+
+public enum CashReceiptType {
+    소득공제, 지출증빙
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/virtualaccount/AccountType.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/virtualaccount/AccountType.java
@@ -1,0 +1,5 @@
+package com.scascanner.studycafe.web.pay.response.etc.virtualaccount;
+
+public enum AccountType {
+    일반, 고정
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/virtualaccount/RefundStatus.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/virtualaccount/RefundStatus.java
@@ -1,0 +1,13 @@
+package com.scascanner.studycafe.web.pay.response.etc.virtualaccount;
+
+/**
+ * 환불 처리 상태입니다. 아래와 같은 상태 값을 가질 수 있습니다.
+ * - NONE: 환불 요청이 없는 상태입니다.
+ * - PENDING: 환불을 처리 중인 상태입니다.
+ * - FAILED: 환불에 실패한 상태입니다.
+ * - PARTIAL_FAILED: 부분 환불에 실패한 상태입니다.
+ * - COMPLETED: 환불이 완료된 상태입니다.
+ */
+public enum RefundStatus {
+    NONE, PENDING, FAILED, PARTIAL_FAILED, COMPLETED
+}

--- a/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/virtualaccount/VirtualAccount.java
+++ b/studycafe/src/main/java/com/scascanner/studycafe/web/pay/response/etc/virtualaccount/VirtualAccount.java
@@ -1,0 +1,30 @@
+package com.scascanner.studycafe.web.pay.response.etc.virtualaccount;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Data
+@NoArgsConstructor
+public class VirtualAccount {
+
+    @JsonValue
+    private AccountType accountType;
+
+    @Length(max = 20, message = "계좌번호는 최대 20자입니다.")
+    private String accountNumber;
+
+    private String bankCode;    // 이거는 추후 BankCode 만들 예정 https://docs.tosspayments.com/reference/codes#은행-코드
+
+    @Length(max = 100, message = "가상계좌 발급 고객 이름은 최대 100자입니다.")
+    private String customerName;
+
+    private String dueDate;
+
+    @JsonValue
+    private RefundStatus refundStatus;
+
+    private boolean expired;
+
+}


### PR DESCRIPTION
## User
- 기존 `id`, `email` 에 대한 getter 메소드만 있던 것을 롬복의 `@Getter` 어노테이션을 사용하여 모든 필드들에 대한 getter 메소드 구현

## PaymentCreateResponse
- 토스페이먼츠에게 결제 요청 api 클래스 추가
- 이는 추후에 CommonPaymentCreateRequestInfo 클래스로 대체될 예정

## etc
- 토스페이먼츠 최종 결제 승인 관련 누락된 클래스들을 추가 
- 자세한 것은 커밋 메시지를 확인해주세요!